### PR TITLE
Matplotlibのバージョン変更

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,8 @@ loguru = "^0.6.0"
 omegaconf = "^2.2.2"
 types-python-dateutil = "^2.8.17"
 gdown = "^4.7.1"
+matplotlib = "3.5.3"
+
 
 [tool.poetry.group.dev.dependencies]
 python-semantic-release = "^8.0.6"


### PR DESCRIPTION
mplsoccerのコードが古く、matplotlib周りでエラーが起きていたので変更。
具体的には、3.6.xでdeprecatedになっているmatplotlib.docstringをimportしようとしていてエラーになっていたので、一旦workaroundとして3.5.3にmatplotlibをダウングレードした。
